### PR TITLE
Fixed some bugs and patched other bug fixes found in the assembler 

### DIFF
--- a/SIC Simulator/Assembler.cs
+++ b/SIC Simulator/Assembler.cs
@@ -93,8 +93,7 @@ namespace SIC_Simulator
             String line;
             while ((line = file.ReadLine()) != null)
             {
-                Regex.Replace(line, @"([ ]+)", "\t"); // thank you J for posting your CLOCK code = ) .. all spaces are replaced with tabs now
-                line = line.TrimEnd();
+                line = Regex.Replace(line, @"([ ]+)", "\t"); // thank you J for posting your CLOCK code = ) .. all spaces are replaced with tabs now
                 line_counter++;
                 if (line[0] == 35 || line.Length == 0) // skip comments and blank lines
                     continue;
@@ -105,6 +104,7 @@ namespace SIC_Simulator
                 }
 
                 String[] lineArray = line.Split('\t');
+
 
                 Instruction instruction_line = new Instruction(lineArray[0], lineArray[1], lineArray.Length == 2 ? "" : lineArray[2], line_counter);
 
@@ -233,7 +233,8 @@ namespace SIC_Simulator
                     {
                         memory_address += len;
                     }
-                    else{
+                    else
+                    {
                         output += String.Format("{0}\nLine {1}:", line, "CONSTANT FORMAT VALIDATION FAILED");
                         MessageBox.Show(output);
                         return;


### PR DESCRIPTION
All processed lines will now be scanned for whitespaces and replaced with tabs. The END directive's first executable address is optional and will default to the START directive memory address if not specified. Removed the print out of the symbol table and SIC source to limit the message box size so a user can click 'OK'.. This update should also handle new bugs introduced in the last pull request. I will start on the automated testing to avoid such errors in the future.