### PR TITLE
Test if device ID is stored in BYTE constant

### DIFF
--- a/SIC Simulator/SIC_CPU.cs
+++ b/SIC Simulator/SIC_CPU.cs
@@ -878,10 +878,14 @@ namespace SIC_Simulator
                     dataByte = (byte)this.A;
                     int DeviceNumberToRead;
                     DeviceNumberToRead = this.FetchWord(TA);
+                    
+                    // in case device ID is stored using a BYTE constan
+                    if((DeviceNumberToRead >> 16) > 0)
+                      DeviceNumberToRead >>= 16;
 
                     // Set Device's Status Word to BUSY
                     this.Devices[DeviceNumberToRead].DeviceSW &= 0xFFFF3F;
-
+                    
                     // Write the byte to the device
                     dataByte = this.Devices[DeviceNumberToRead].ReadByte();
 
@@ -1000,6 +1004,10 @@ namespace SIC_Simulator
                     dataByteW = (byte)this.A;
                     int DeviceNumberToWriteTo;
                     DeviceNumberToWriteTo = this.FetchWord(TA);
+                    
+                    // in case device ID was stored using a BYTE constant
+                    if((DeviceNumberToWriteTo >> 16) > 0)
+                        DeviceNumberToWriteTo >>= 16;
 
                     // Set Device's Status Word to BUSY
                     this.Devices[DeviceNumberToWriteTo].DeviceSW &= 0xFFFF3F;


### PR DESCRIPTION
Currently, for instructions that read/write to I/O devices, the logic in the FetchWord method in the SIC_CPU.cs assumes that device ID's are stored in data words. The effect of this is that FetchWord retrieves the next three bytes of data starting from the contents of the Target Address. This is a problem if a SIC file writer decides to store a device ID using the BYTE directive because FetchWord will read two bytes beyond what is necessary and assign an invalid number to the DeviceNumberToWriteTo or DeviceNumberToRead int values, and ultimately cause an "array out of bounds" exception.